### PR TITLE
fic(cpp): add missing include

### DIFF
--- a/cpp/negentropy/encoding.h
+++ b/cpp/negentropy/encoding.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdint.h>
 #include <string_view>
 
 


### PR DESCRIPTION
The build was failing for me here and in nwaku repository, but this seems to solve it

```
$ make
g++ -O0 --std=c++20 -Wall -fexceptions -g negentropy.h -I./ -I/opt/homebrew/include/ -I./vendor/lmdbxx/include/
negentropy.h:3:9: warning: #pragma once in main file
    3 | #pragma once
      |         ^~~~
In file included from negentropy.h:19:
negentropy/encoding.h:12:8: error: ‘uint8_t’ does not name a type
   12 | inline uint8_t getByte(std::string_view &encoded) {
      |        ^~~~~~~
negentropy/encoding.h:1:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
  +++ |+#include <cstdint>
    1 | #pragma once
negentropy/encoding.h:26:8: error: ‘uint64_t’ does not name a type
   26 | inline uint64_t decodeVarInt(std::string_view &encoded) {
      |        ^~~~~~~~
negentropy/encoding.h:26:8: note: ‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
negentropy/encoding.h:40:33: error: ‘uint64_t’ was not declared in this scope
   40 | inline std::string encodeVarInt(uint64_t n) {
      |                                 ^~~~~~~~
negentropy/encoding.h:40:33: note: ‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
negentropy/encoding.h:40:45: error: expected ‘,’ or ‘;’ before ‘{’ token
   40 | inline std::string encodeVarInt(uint64_t n) {
      |                                             ^
In file included from negentropy.h:20:
negentropy/types.h: In member function ‘negentropy::Fingerprint negentropy::Accumulator::getFingerprint(uint64_t)’:
negentropy/types.h:171:30: error: no match for call to ‘(std::string {aka std::__cxx11::basic_string<char>}) (uint64_t&)’
  171 |         input += encodeVarInt(n);
      |                  ~~~~~~~~~~~~^~~
negentropy.h: In member function ‘std::string negentropy::Negentropy<StorageImpl>::reconcileAux(std::string_view, std::vector<std::__cxx11::basic_string<char> >&, std::vector<std::__cxx11::basic_string<char> >&)’:
negentropy.h:84:32: error: there are no arguments to ‘getByte’ that depend on a template parameter, so a declaration of ‘getByte’ must be available [-fpermissive]
   84 |         auto protocolVersion = getByte(query);
      |                                ^~~~~~~
negentropy.h:84:32: note: (if you use ‘-fpermissive’, G++ will accept your code, but allowing the use of an undeclared name is deprecated)
negentropy.h: In lambda function:
negentropy.h:103:38: error: no match for call to ‘(std::string {aka std::__cxx11::basic_string<char>}) (uint64_t)’
  103 |                     o += encodeVarInt(uint64_t(Mode::Skip));
      |                          ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
negentropy.h: In member function ‘std::string negentropy::Negentropy<StorageImpl>::reconcileAux(std::string_view, std::vector<std::__cxx11::basic_string<char> >&, std::vector<std::__cxx11::basic_string<char> >&)’:
negentropy.h:108:30: error: there are no arguments to ‘decodeVarInt’ that depend on a template parameter, so a declaration of ‘decodeVarInt’ must be available [-fpermissive]
  108 |             auto mode = Mode(decodeVarInt(query));
      |                              ^~~~~~~~~~~~
negentropy.h:126:31: error: there are no arguments to ‘decodeVarInt’ that depend on a template parameter, so a declaration of ‘decodeVarInt’ must be available [-fpermissive]
  126 |                 auto numIds = decodeVarInt(query);
      |                               ^~~~~~~~~~~~
negentropy.h:175:38: error: no match for call to ‘(std::string {aka std::__cxx11::basic_string<char>}) (uint64_t)’
  175 |                     o += encodeVarInt(uint64_t(Mode::IdList));
      |                          ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
negentropy.h:176:38: error: no match for call to ‘(std::string {aka std::__cxx11::basic_string<char>}) (uint64_t&)’
  176 |                     o += encodeVarInt(numResponseIds);
      |                          ~~~~~~~~~~~~^~~~~~~~~~~~~~~~
negentropy.h:191:43: error: no match for call to ‘(std::string {aka std::__cxx11::basic_string<char>}) (uint64_t)’
  191 |                 fullOutput += encodeVarInt(uint64_t(Mode::Fingerprint));
      |                               ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
negentropy.h: In member function ‘std::string negentropy::Negentropy<StorageImpl>::splitRange(size_t, size_t, const negentropy::Bound&)’:
negentropy.h:213:30: error: no match for call to ‘(std::string {aka std::__cxx11::basic_string<char>}) (uint64_t)’
  213 |             o += encodeVarInt(uint64_t(Mode::IdList));
      |                  ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
negentropy.h:215:30: error: no match for call to ‘(std::string {aka std::__cxx11::basic_string<char>}) (uint64_t&)’
  215 |             o += encodeVarInt(numElems);
      |                  ~~~~~~~~~~~~^~~~~~~~~~
negentropy.h:247:34: error: no match for call to ‘(std::string {aka std::__cxx11::basic_string<char>}) (uint64_t)’
  247 |                 o += encodeVarInt(uint64_t(Mode::Fingerprint));
      |                      ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
negentropy.h: In member function ‘uint64_t negentropy::Negentropy<StorageImpl>::decodeTimestampIn(std::string_view&)’:
negentropy.h:262:30: error: there are no arguments to ‘decodeVarInt’ that depend on a template parameter, so a declaration of ‘decodeVarInt’ must be available [-fpermissive]
  262 |         uint64_t timestamp = decodeVarInt(encoded);
      |                              ^~~~~~~~~~~~
negentropy.h: In member function ‘negentropy::Bound negentropy::Negentropy<StorageImpl>::decodeBound(std::string_view&)’:
negentropy.h:272:20: error: there are no arguments to ‘decodeVarInt’ that depend on a template parameter, so a declaration of ‘decodeVarInt’ must be available [-fpermissive]
  272 |         auto len = decodeVarInt(encoded);
      |                    ^~~~~~~~~~~~
negentropy.h: In member function ‘std::string negentropy::Negentropy<StorageImpl>::encodeTimestampOut(uint64_t)’:
negentropy.h:281:32: error: no match for call to ‘(std::string {aka std::__cxx11::basic_string<char>}) (int)’
  281 |             return encodeVarInt(0);
      |                    ~~~~~~~~~~~~^~~
negentropy.h:287:28: error: no match for call to ‘(std::string {aka std::__cxx11::basic_string<char>}) (uint64_t)’
  287 |         return encodeVarInt(timestamp + 1);
      |                ~~~~~~~~~~~~^~~~~~~~~~~~~~~
negentropy.h: In member function ‘std::string negentropy::Negentropy<StorageImpl>::encodeBound(const negentropy::Bound&)’:
negentropy.h:294:31: error: no match for call to ‘(std::string {aka std::__cxx11::basic_string<char>}) (const size_t&)’
  294 |         output += encodeVarInt(bound.idLen);
      |                   ~~~~~~~~~~~~^~~~~~~~~~~~~
make: *** [Makefile:18: precompiled-header] Error 1

```

Not sure if there is better/proper way to do this?