### PR TITLE
negentropy.h avoid use non standard #pragma one

### DIFF
--- a/cpp/negentropy.h
+++ b/cpp/negentropy.h
@@ -1,6 +1,7 @@
 // (C) 2023 Doug Hoyte. MIT license
 
-#pragma once
+#ifndef _NEGENTROPY_H_
+#define _NEGENTROPY_H_
 
 #include <string.h>
 
@@ -321,3 +322,5 @@ struct Negentropy {
 
 template<typename T>
 using Negentropy = negentropy::Negentropy<T>;
+
+#endif


### PR DESCRIPTION
This tiny PR aims to avoid the following warning, when compiling:

![image](https://github.com/user-attachments/assets/d3c8c080-3a2c-46b5-86f0-77dfb8c262e1)
