### PR TITLE
chore: update makefile to give support major os

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -1,7 +1,8 @@
 # Build a shared library of negentropy
 
-#TODO: Need to add compilation flags based on OS
-INCS	= -I./ -I/opt/homebrew/include/ -I./vendor/lmdbxx/include/
+# Define the root directory of the negentropy project; this absolute path mechanism works across all major os
+NEGENTROPY_ROOT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+INCS	= -I$(NEGENTROPY_ROOT) -I/opt/homebrew/include/ -I$(NEGENTROPY_ROOT)/vendor/lmdbxx/include/
 TARGET  = libnegentropy.so
 
 .PHONY: all clean install-deps precompiled-header shared-lib
@@ -14,10 +15,10 @@ install-deps:
 
 # Generate 'negentropy.h.gch'
 precompiled-header:
-	g++ -O0 --std=c++20 -Wall -fexceptions -g negentropy.h $(INCS)
+	g++ -O0 --std=c++20 -Wall -fexceptions -g $(NEGENTROPY_ROOT)negentropy.h $(INCS)
 
 shared-lib:
-	g++ -O0 -g -std=c++20 $(INCS) -shared -fPIC -o $(TARGET) negentropy_wrapper.cpp -lcrypto -lssl -L/opt/homebrew/lib/
+	g++ -O0 -g -std=c++20 $(INCS) -shared -fPIC -o $(TARGET) $(NEGENTROPY_ROOT)negentropy_wrapper.cpp -lcrypto -lssl -L/opt/homebrew/lib/
 
 clean:
 	rm -f $(TARGET) negentropy.h.gch libnegentropy.so

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -3,7 +3,12 @@
 # Define the root directory of the negentropy project; this absolute path mechanism works across all major os
 NEGENTROPY_ROOT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 INCS	= -I$(NEGENTROPY_ROOT) -I/opt/homebrew/include/ -I$(NEGENTROPY_ROOT)/vendor/lmdbxx/include/
-TARGET  = libnegentropy.so
+
+ifeq ($(OS),Windows_NT)
+	TARGET  = negentropy.dll
+else
+	TARGET  = libnegentropy.so
+endif
 
 .PHONY: all clean install-deps precompiled-header shared-lib
 


### PR DESCRIPTION
this change enables negentropy to build on all major operating systems (windows, linux, macos). previously, it was limited to linux.