### PR TITLE
fix: building static library only in linux

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -6,8 +6,10 @@ INCS	= -I$(NEGENTROPY_ROOT) -I/opt/homebrew/include/ -I$(NEGENTROPY_ROOT)/vendor
 
 ifeq ($(detected_OS),Linux)
 	TARGET  = libnegentropy.a
-else
+else ifeq ($(OS),Windows_NT)
 	TARGET  = libnegentropy.dll
+else
+	TARGET  = libnegentropy.so
 endif
 
 .PHONY: all clean install-deps precompiled-header build-lib

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -4,10 +4,10 @@
 NEGENTROPY_ROOT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 INCS	= -I$(NEGENTROPY_ROOT) -I/opt/homebrew/include/ -I$(NEGENTROPY_ROOT)/vendor/lmdbxx/include/
 
-ifeq ($(OS),Windows_NT)
-	TARGET  = libnegentropy.dll
-else
+ifeq ($(detected_OS),Linux)
 	TARGET  = libnegentropy.a
+else
+	TARGET  = libnegentropy.dll
 endif
 
 .PHONY: all clean install-deps precompiled-header build-lib
@@ -23,11 +23,11 @@ precompiled-header:
 	g++ -O0 --std=c++20 -Wall -fexceptions -g $(NEGENTROPY_ROOT)negentropy.h $(INCS)
 
 build-lib:
-ifeq ($(OS),Windows_NT)
-	g++ -O0 -g -std=c++20 $(INCS) -shared -fPIC -o $(TARGET) $(NEGENTROPY_ROOT)negentropy_wrapper.cpp -lcrypto -lssl -L/opt/homebrew/lib/
-else
+ifeq ($(detected_OS),Linux)
 	g++ -O0 -g -std=c++20 $(INCS) -fPIC -c negentropy_wrapper.cpp
 	ar rcs $(TARGET) negentropy_wrapper.o
+else
+	g++ -O0 -g -std=c++20 $(INCS) -shared -fPIC -o $(TARGET) $(NEGENTROPY_ROOT)negentropy_wrapper.cpp -lcrypto -lssl -L/opt/homebrew/lib/
 endif
 
 clean:


### PR DESCRIPTION
MacOs builds were failing as it was trying to build the static lib and not yet compatible for it.
Will only build the static lib if the OS is linux