### PR TITLE
fix: indicate to the compiler that negentropy.h will be a precompiled header

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -20,7 +20,7 @@ install-deps:
 
 # Generate 'negentropy.h.gch'
 precompiled-header:
-	g++ -O0 --std=c++20 -Wall -fexceptions -g $(NEGENTROPY_ROOT)negentropy.h $(INCS)
+	g++ -x c++-header -O0 --std=c++20 -Wall -fexceptions -g -o $(NEGENTROPY_ROOT)negentropy.h.gch $(NEGENTROPY_ROOT)negentropy.h $(INCS)
 
 build-lib:
 ifeq ($(OS),Windows_NT)


### PR DESCRIPTION
Otherwise when compiling under nix (like we do in status-go), 
```
-glibc-2.38-44/lib/crt1.o: in function _start':
(.text+0x1b): undefined reference to main'
```