### PR TITLE
chore: dynamic library ( no longer required )

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -4,11 +4,7 @@
 NEGENTROPY_ROOT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 INCS	= -I$(NEGENTROPY_ROOT) -I/opt/homebrew/include/ -I$(NEGENTROPY_ROOT)/vendor/lmdbxx/include/
 
-ifeq ($(OS),Windows_NT)
-	TARGET  = libnegentropy.dll
-else
-	TARGET  = libnegentropy.a
-endif
+TARGET  = libnegentropy.a
 
 .PHONY: all clean install-deps precompiled-header build-lib
 


### PR DESCRIPTION
There was a migration in the nwaku repo from a dynamic to a static library a few weeks ago. now, all operating systems can use the negentropy library as a static build.